### PR TITLE
Reverting my earlier fix to force php 7 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 sudo: false # use container-based Travis infrastructure
 node_js:
   - "6"
-before_install:
-  - phpenv global 7.0 #switch to php7, since that's what php-Tooling extension requires
 before_script:
   - npm install -g grunt-cli
   - npm install -g jasmine-node


### PR DESCRIPTION
No longer required since 7.2 is the default php version.
7.0 is no longer supported in travis, which is causing travis build to
fail.